### PR TITLE
Comprehensive correction of implementation of flash messages.

### DIFF
--- a/app/controllers/things_controller/create_responder.rb
+++ b/app/controllers/things_controller/create_responder.rb
@@ -35,6 +35,12 @@ class ThingsController < ApplicationController
       self
     end
 
+    def encode_errors_to_flash
+      error_str = Views::Things::Shared::MessageEncoder.encode @thing.errors
+      controller.flash[:error] = error_str
+      self
+    end
+
     def handle_result
       return handle_success if @thing.valid?
       handle_failure
@@ -42,7 +48,7 @@ class ThingsController < ApplicationController
 
     def handle_failure
       # Controller's @thing should already be set by this point per yield
-      # Rails.logger.debug 'Flashes in responder', flash: controller.flash.to_h
+      encode_errors_to_flash
       controller.render 'new'
       self
     end

--- a/app/controllers/things_controller/index_responder.rb
+++ b/app/controllers/things_controller/index_responder.rb
@@ -9,7 +9,7 @@ class ThingsController < ApplicationController
     # Methods neither depending on nor affecting instance state
     module Internals
       def self.all_the_things
-        Thing.all.sort_by(&:id)
+        Thing.for_index
       end
     end
     private_constant :Internals
@@ -35,7 +35,7 @@ class ThingsController < ApplicationController
     end
 
     def handle_success
-      controller.flash[:info] = flash_message
+      controller.flash[:notice] = flash_message
       self
     end
   end # class ThingsController::IndexResponder

--- a/app/models/thing.rb
+++ b/app/models/thing.rb
@@ -1,4 +1,10 @@
 
 # Sequel ORM representation of 'thing' table. This should have NO domain logic.
 class Thing < Sequel::Model
+  # Define some "scopes" (filters and/or ordering of the dataset)
+  dataset_module do
+    def for_index
+      all.sort_by(&:id)
+    end
+  end # dataset_module
 end

--- a/app/views/things/shared/flashes.rb
+++ b/app/views/things/shared/flashes.rb
@@ -9,8 +9,34 @@ module Views
         needs :flashes
 
         def content
-          flashes.each_entry do |type, message|
-            widget FlashAlert, message: message, type: type
+          render_other_flashes
+          render_error_flashes
+        end
+
+        private
+
+        def decoded_errors
+          error_str = flashes[:error].to_s
+          Views::Things::Shared::MessageEncoder.decode error_str
+        end
+
+        def other_flashes
+          flashes.to_h.reject { |key, _value| key.to_sym == :error }
+        end
+
+        def render_alert(message:, type:)
+          widget FlashAlert, message: message, type: type
+        end
+
+        def render_error_flashes
+          decoded_errors.each do |message|
+            render_alert message: message, type: :error
+          end
+        end
+
+        def render_other_flashes
+          other_flashes.each_entry do |type, message|
+            render_alert message: message, type: type
           end
         end
       end # class Views::Things::Shared::Flashes

--- a/app/views/things/shared/message_encoder.rb
+++ b/app/views/things/shared/message_encoder.rb
@@ -1,0 +1,28 @@
+
+module Views
+  module Things
+    module Shared
+      # Shared utility class (not really a widget) to encode/decode messages,
+      # such as one or more error messages, into or from a single string.
+      #   Decoding accounts for input that is either a simple string or an
+      # encoded string representing either a simple string or an array of simple
+      # strings; decoding always returns an array, even with a single element.
+      #   Encoding permits input that is either a string or an array of strings;
+      # it always returns a string.
+      #
+      # NOTE: This really *ought* to be completely separated from the view
+      #       hierarchy.
+      class MessageEncoder
+        def self.encode(input)
+          JSON.dump Array(input)
+        end
+
+        def self.decode(input)
+          Array(JSON.load input)
+        rescue JSON::ParserError
+          Array(input.to_s)
+        end
+      end # class Views::Things::Shared::MessageEncoder
+    end
+  end
+end

--- a/test/controllers/things_controller/index_responder_test.rb
+++ b/test/controllers/things_controller/index_responder_test.rb
@@ -53,7 +53,7 @@ describe 'ThingsController::IndexResponder' do
     it "assigns to the controller's success flash message" do
       obj.call { |_| }
       expected = "There are currently #{count} things in the system."
-      expect(dummy_controller.flash[:info]).must_equal expected
+      expect(dummy_controller.flash[:notice]).must_equal expected
     end
   end # describe 'has a #call method that'
 end # describe 'ThingsController::IndexResponder'

--- a/test/controllers/things_controller_test.rb
+++ b/test/controllers/things_controller_test.rb
@@ -102,13 +102,11 @@ describe 'ThingsController' do
           expect(thing).wont_be :valid?
         end
 
-        # The assumption here is that the controller doesn't set any flash
-        # messages because it commanded the re-rendering of the new-user page.
-        # When that page is fully functional, it will retrieve the validation
-        # error messages from the User object handed to it and display those
-        # appropriately.
-        it 'sets no flash messages' do
-          expect(flash).must_be_empty
+        # Now that validation is properly hooked in, it complains bitterly.
+        it 'sets correct encoded error-flash message for failed validation' do
+          expected = ["Name can't be blank", 'Initial quantity is not a number',
+                      "Description can't be blank"]
+          expect(flash[:error]).must_equal JSON.dump(expected)
         end
       end # describe 'assigns to the :thing variable'
     end # describe 'with invalid field values'

--- a/test/views/things/shared/message_encoder_test.rb
+++ b/test/views/things/shared/message_encoder_test.rb
@@ -1,0 +1,118 @@
+
+require 'test_helper'
+
+describe 'Views::Things::Shared::MessageEncoder' do
+  let(:described_class) { Views::Things::Shared::MessageEncoder }
+  let(:simple_input_string) { 'A simple input string.' }
+  let(:multiple_strings) do
+    ['String 1', 'String 2', 'String 3']
+  end
+
+  describe 'has an .encode method that, when given input of' do
+    let(:subject) { described_class.method :encode }
+
+    # If you encode an already-encoded string, then you are On Your Own.
+    describe 'a simple string, produces' do
+      let(:output) { subject.call simple_input_string }
+
+      it 'a string as output' do
+        expect(output).must_respond_to :to_str
+      end
+
+      it 'JSON-encoded output' do
+        expect { JSON.load output }.must_be_silent
+      end
+
+      it 'an encoded array (of strings)' do
+        decoded = JSON.load output
+        expect(decoded).must_respond_to :to_a
+      end
+
+      it 'an encoded single-element array' do
+        decoded = JSON.load output
+        expect(decoded.count).must_equal 1
+      end
+
+      it 'an encoding of the input string as the encoded array element' do
+        decoded = JSON.load output
+        expect(decoded.first).must_equal simple_input_string
+      end
+    end # describe 'a simple string, produces'
+
+    describe 'an Array-like enumeration of strings, produces' do
+      let(:output) { subject.call multiple_strings }
+
+      it 'a string as output' do
+        expect(output).must_respond_to :to_str
+      end
+
+      it 'JSON-encoded output' do
+        expect { JSON.load output }.must_be_silent
+      end
+
+      it 'an encoded multi-element array of strings' do
+        decoded = JSON.load output
+        expect(decoded).must_respond_to :to_a
+      end
+
+      it 'an encoded array encoding each item in the input array' do
+        decoded = JSON.load(output)
+        expect(decoded).must_equal multiple_strings
+      end
+    end # describe 'an Array-like enumeration of strings, produces'
+  end # describe 'has an .encode method that, when given input of'
+
+  describe 'has a .decode method that, when given input of' do
+    let(:subject) { described_class.method :decode }
+
+    describe 'a simple string, produces' do
+      let(:output) { subject.call simple_input_string }
+
+      it 'an array as output' do
+        expect(output).must_be_instance_of Array
+      end
+
+      it 'an array with a single element' do
+        expect(output.count).must_equal 1
+      end
+
+      it 'an array containing the input string as its single element' do
+        expect(output.first).must_equal simple_input_string
+      end
+    end # describe 'a simple string, produces'
+
+    describe 'an encoded string, produces' do
+      let(:input) { JSON.dump simple_input_string }
+      let(:output) { subject.call input }
+
+      it 'an array as output' do
+        expect(output).must_be_instance_of Array
+      end
+
+      it 'an array with a single element' do
+        expect(output.count).must_equal 1
+      end
+
+      it 'an array containing the decoded input string as its single element' do
+        expect(output.first).must_equal simple_input_string
+      end
+    end # describe 'an encoded string, produces'
+
+    describe 'an encoded array of strings, produces' do
+      let(:input) { JSON.dump multiple_strings }
+      let(:output) { subject.call input }
+
+      it 'an array as output' do
+        expect(output).must_be_instance_of Array
+      end
+
+      it 'an array with the correct number of elements' do
+        expect(output.count).must_equal multiple_strings.count
+      end
+
+      it 'an array containing the decoded input strings as elements' do
+        expect(output).must_equal multiple_strings
+      end
+    end # describe 'an encoded array of strings, produces'
+  end # describe 'has a .decode method that, when given input of'
+end # describe 'Views::Things::Shared::MessageEncoder'


### PR DESCRIPTION
As per Issue #11, expanded to include all instances of flash messages (in the index view after a successful add or in the new-thing view after a failed validation causes the new-thing form to be redisplayed).
